### PR TITLE
Add simple UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The tracker requires Python 3.8+. No external packages are needed.
 python ca_tracker/cli.py --help
 ```
 
+Alternatively you can run a very simple menu-driven interface:
+
+```bash
+python simple_ui.py
+```
+
 ## Usage
 
 1. **Set targets**:

--- a/simple_ui.py
+++ b/simple_ui.py
@@ -1,0 +1,49 @@
+import sys
+from ca_tracker.cli import set_targets, add_sale, status
+
+
+def prompt_float(message):
+    while True:
+        try:
+            return float(input(message))
+        except ValueError:
+            print("Please enter a valid number.")
+
+
+def prompt_date(message):
+    date = input(message + " (YYYY-MM-DD, leave blank for today): ")
+    return date or None
+
+
+def main():
+    while True:
+        print("\nCA Tracker")
+        print("1. Set targets")
+        print("2. Add sale")
+        print("3. Show status")
+        print("4. Exit")
+        choice = input("Choose an option: ")
+
+        if choice == "1":
+            daily = prompt_float("Daily target: ")
+            weekly = prompt_float("Weekly target: ")
+            monthly = prompt_float("Monthly target: ")
+            set_targets(daily, weekly, monthly)
+        elif choice == "2":
+            amount = prompt_float("Sale amount: ")
+            date_str = prompt_date("Date")
+            add_sale(amount, date_str)
+        elif choice == "3":
+            status()
+        elif choice == "4":
+            print("Goodbye!")
+            break
+        else:
+            print("Invalid choice, try again.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)


### PR DESCRIPTION
## Summary
- add `simple_ui.py` with a menu for novices
- document how to run the menu in the README

## Testing
- `python -m py_compile ca_tracker/cli.py simple_ui.py`
- `python simple_ui.py <<EOF
4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6850997e9eac8325b965daf752ca07e8